### PR TITLE
Run nats as nonroot. Making use of userid 65534 (nobody).

### DIFF
--- a/charts/stigatron/values.yaml
+++ b/charts/stigatron/values.yaml
@@ -58,8 +58,19 @@ nats:
     jetstream:
       enabled: true
       fileStore:
+        enabled: true
+        dir: /tmp/jetstream
         pvc:
           enabled: false
+  podTemplate:
+    configChecksumAnnotation: true
+    merge:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          fsGroup: 65534
+          runAsUser: 65534
+          runAsGroup: 65534
 global:
   cattle:
     systemDefaultRegistry: "rgcrprod.azurecr.us"


### PR DESCRIPTION
@dweomer - memoryStore didn't work and I was seeing a runtime error: `Failed getting KeyValue for bucket: carbide-compliance-alerts. error: nats: bucket not found
Create the bucketFailed creating KeyValue store for carbide-compliance-alerts. error: nats: API error: code=500 err_code=10047 description=insufficient storage resources available`

So, instead using directory `/tmp/jetstream`