### PR TITLE
Draft:  updates for rancher 2.8.0

### DIFF
--- a/charts/rancher/Chart.yaml
+++ b/charts/rancher/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers
-version: 2.7.9
-appVersion: v2.7.9
-kubeVersion: < 1.27.0-0
+version: 2.8.0
+appVersion: v2.8.0
+kubeVersion: < 1.28.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
 keywords:

--- a/charts/rancher/values.yaml
+++ b/charts/rancher/values.yaml
@@ -155,7 +155,7 @@ postDelete:
   enabled: true
   image:
     repository: rancher/shell
-    tag: v0.1.21
+    tag: v0.1.22
   namespaceList:
     - cattle-fleet-system
     - cattle-system
@@ -190,4 +190,4 @@ carbide:
   whitelabel:
     enabled: true
     image: carbide/carbide-whitelabel
-    tag: "0.1.1"
+    tag: "0.1.2"


### PR DESCRIPTION
* this requires a bump to the whitelabel image because of 3 new images plus 2 updated ones.
* more testing needs to take place before merging.