### PR TITLE
updated code to match carbide-docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,15 @@
-name: Release Charts
-
+name: Release Helm Chart(s)
 on:
   push:
     branches:
-      - release 
+      - release
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -19,7 +18,23 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+      - name: Run Helm Chart Releaser
+        uses: helm/chart-releaser-action@v1.6.0
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Chart(s) to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,19 +22,3 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
-      - name: Authenticate to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Chart(s) to GHCR
-        run: |
-          for pkg in .cr-release-packages/*; do
-            if [ -z "${pkg:-}" ]; then
-              break
-            fi
-            helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
-          done

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Rancher Government Carbide Helm Charts
+# Carbide Helm Charts
 
 ### Available Helm Charts
-
-Please note the Carbide Charts are updated frequently. Below an example of the available charts.
 
 ```bash
 NAME                            CHART VERSION   APP VERSION     DESCRIPTION
@@ -31,13 +29,6 @@ helm install <release-name> carbide-charts/<chart>
 
 If you would like to do add the Carbide Helm Charts to the Rancher Manager Chart Catalog, so you are able to use the user interface to install them, please follow the steps in the [Rancher Manager Docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher).
 
-### For Helm Chart OCI Artifacts
-
-```bash
-# example install of a helm chart
-helm install <release-name> oci://ghcr.io/rancherfederal/<chart>
-```
-
 ## How to Use (Airgaped Environments)
 
 ### For Helm Chart Repositories
@@ -45,35 +36,33 @@ helm install <release-name> oci://ghcr.io/rancherfederal/<chart>
 #### On Connected Environment
 
 ```bash
-# add and update the helm chart repository
-helm repo add carbide-charts https://rancherfederal.github.io/carbide-charts
-helm repo update
+# generate the hauler manfiest for the carbide charts
+cat <<EOF > carbide-charts.yaml
+apiVersion: content.hauler.cattle.io/v1alpha1
+kind: Charts
+metadata:
+  name: carbide-charts
+spec:
+  charts:
+    - name: airgapped-docs
+      repoURL: https://rancherfederal.github.io/carbide-charts
+      version: 0.1.47
+    - name: heimdall2
+      repoURL: https://rancherfederal.github.io/carbide-charts
+      version: 0.1.45
+    - name: rancher
+      repoURL: https://rancherfederal.github.io/carbide-charts
+      version: 2.8.2
+    - name: stigatron
+      repoURL: https://rancherfederal.github.io/carbide-charts
+      version: 0.2.5
+    - name: stigatron-ui
+      repoURL: https://rancherfederal.github.io/carbide-charts
+      version: 0.2.3
+EOF
 
-# view the charts in the helm chart repository
-helm search repo carbide-charts
-
-# save and output the helm chart to tarball
-helm pull carbide-charts/<chart>
-```
-
-#### On Airgapped Environment
-
-```bash
-# example install of a helm chart
-helm install <release-name> <chart>.tgz
-```
-
-### For Helm Chart OCI Artifacts
-
-#### On Connected Environment
-
-```bash
-# authenticate into carbide secured registry
-cosign login -u <redacted> -p <redacted> rgcrprod.azurecr.us
-
-# fetch the content from the carbide secured registry
-# verify the version, location of the key, and the platform/architecture
-hauler store sync --products carbide-charts=v0.1.1 --key carbide-key.pub --platform linux/amd64
+# fetch the content from generated hauler manifest
+hauler store sync -f carbide-charts.yaml
 
 # save and output the content from the hauler store to tarball
 hauler store save --filename carbide-charts.tar.zst
@@ -85,9 +74,9 @@ hauler store save --filename carbide-charts.tar.zst
 # load the content from the tarball to the hauler store
 hauler store load carbide-charts.tar.zst
 
-# copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+# server the content from the hauler store
+hauler store serve fileserver
 
-# save and output the helm chart to tarball
-helm install <release-name> oci://ghcr.io/rancherfederal/<chart>
+# example install of a helm chart
+helm install <release-name> http://<FQDN or IP>:<PORT>/<chart>.tgz
 ```

--- a/README.md
+++ b/README.md
@@ -1,37 +1,93 @@
 # Rancher Government Carbide Helm Charts
 
-Still a WIP!
+### Available Helm Charts
+
+Please note the Carbide Charts are updated frequently. Below an example of the available charts.
+
+```bash
+NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+carbide-charts/airgapped-docs   0.1.47          0.1.2           Rancher Government Airgapped Docs
+carbide-charts/heimdall2        0.1.45          0.1.1           Rancher Government Heimdall2 Tool
+carbide-charts/rancher          2.8.2           v2.8.2          Install Rancher Server to manage Kubernetes...
+carbide-charts/stigatron        0.2.5           0.2.2           Rancher Government Stigatron Extension
+carbide-charts/stigatron-ui     0.2.3           0.2.0           Rancher Government Stigatron UI Extension
+```
 
 ## How To Use (Connected Environments)
 
-```
+### For Helm Chart Repositories
+
+```bash
+# add and update the helm chart repository
 helm repo add carbide-charts https://rancherfederal.github.io/carbide-charts
 helm repo update
+
+# view the charts in the helm chart repository
 helm search repo carbide-charts
-helm install example-release carbide-charts/<chart>
+
+# example install of a helm chart
+helm install <release-name> carbide-charts/<chart>
 ```
 
-If you would like to do add the carbide-charts to the Rancher Manager Chart Catalog, please follow the steps in the [Rancher Manager Docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps#docusaurus_skipToContent_fallback) and use the following chart catalog Git Repo URL with the branch name of main:
+If you would like to do add the Carbide Helm Charts to the Rancher Manager Chart Catalog, so you are able to use the user interface to install them, please follow the steps in the [Rancher Manager Docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher).
 
-```
-https://github.com/rancherfederal/carbide-charts.git
+### For Helm Chart OCI Artifacts
+
+```bash
+# example install of a helm chart
+helm install <release-name> oci://ghcr.io/rancherfederal/<chart>
 ```
 
 ## How to Use (Airgaped Environments)
 
-### On Connected Environment
+### For Helm Chart Repositories
 
-```
+#### On Connected Environment
+
+```bash
+# add and update the helm chart repository
 helm repo add carbide-charts https://rancherfederal.github.io/carbide-charts
 helm repo update
+
+# view the charts in the helm chart repository
 helm search repo carbide-charts
+
+# save and output the helm chart to tarball
 helm pull carbide-charts/<chart>
 ```
 
-Take the resulting `tgz` file over the airgap.
-    
-### On Airgapped Environment
+#### On Airgapped Environment
 
+```bash
+# example install of a helm chart
+helm install <release-name> <chart>.tgz
 ```
-helm install example-release <chart-example>.tgz
+
+### For Helm Chart OCI Artifacts
+
+#### On Connected Environment
+
+```bash
+# authenticate into carbide secured registry
+cosign login -u <redacted> -p <redacted> rgcrprod.azurecr.us
+
+# fetch the content from the carbide secured registry
+# verify the version, location of the key, and the platform/architecture
+hauler store sync --products carbide-charts=v0.1.1 --key carbide-key.pub --platform linux/amd64
+
+# save and output the content from the hauler store to tarball
+hauler store save --filename carbide-charts.tar.zst
+```
+
+#### On Airgapped Environment
+
+```bash
+# load the content from the tarball to the hauler store
+hauler store load carbide-charts.tar.zst
+
+# copy the content from the hauler store to your registry
+hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+
+# save and output the helm chart to tarball
+helm install <release-name> oci://ghcr.io/rancherfederal/<chart>
 ```


### PR DESCRIPTION
* Updated the workflow `release.yaml` to support publishing Helm Chart OCI Artifacts
* Updated the `README` to match the newly updated `carbide-docs`
  * https://github.com/rancherfederal/carbide-docs/pull/85