### PR TITLE
stigatron v0.4.2 upgrade

### DIFF
--- a/charts/stigatron/Chart.yaml
+++ b/charts/stigatron/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stigatron
-version: 0.4.1
-appVersion: 0.4.0
+version: 0.4.2
+appVersion: 0.4.2
 
 type: application
 description: Rancher Government Stigatron Extension

--- a/charts/stigatron/values.yaml
+++ b/charts/stigatron/values.yaml
@@ -1,13 +1,13 @@
 complianceOperator:
   image:
     name: carbide/compliance-operator
-    tag: "0.4.0"
+    tag: "0.4.2"
   imagePullPolicy: Always
   serviceAccountName: stigatron
 heimdallOperator:
   image:
     name: carbide/heimdall-operator
-    tag: "0.4.0"
+    tag: "0.4.2"
   imagePullPolicy: Always
   serviceAccountName: stigatron
   database:


### PR DESCRIPTION
Update to fix CIS Operator compatibility issues.

Validated with Rancher v2.9.x.

Latest CIS Operator (v6.7.0):
<img width="1711" alt="Screenshot 2025-03-12 at 5 34 53 PM" src="https://github.com/user-attachments/assets/66f223eb-93a1-4465-9624-eae54c0360e3" />

Old-format CIS Operator (v6.3.0):
<img width="1703" alt="Screenshot 2025-03-12 at 5 38 31 PM" src="https://github.com/user-attachments/assets/a3fc1e00-d367-49ea-8f2a-1a53a1468753" />


